### PR TITLE
Add translation and summarization prompt examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A robust full-stack template for building AI-powered chat and text applications 
 - **CORS configured** for smooth local development
 - **Port flexibility** (backend defaults to 5050, easy to change)
 - **Ready-to-use** `/api/chat` POST endpoint for AI conversations
+- **Sample prompt scripts** for translation and summarization in `src/prompts`
 
 ---
 
@@ -33,11 +34,12 @@ A robust full-stack template for building AI-powered chat and text applications 
 
 ```
 /
-├── frontend/      # React app
-└── backend/       # Express server (proxy to OpenAI)
-      ├── server.js
-      ├── .env     # (your OpenAI API key goes here, never commit)
-      └── ...
+├── public/          # Static assets
+├── src/
+│   ├── App.js       # React app
+│   ├── backend/     # Express server (proxy to OpenAI)
+│   └── prompts/     # Example prompt scripts
+└── ...
 ```
 
 ---
@@ -47,7 +49,7 @@ A robust full-stack template for building AI-powered chat and text applications 
 ### 1. **Backend**
 
 ```bash
-cd backend
+cd src/backend
 npm install
 npm start
 ```
@@ -56,7 +58,6 @@ npm start
 ### 2. **Frontend**
 
 ```bash
-cd frontend
 npm install
 npm start
 ```
@@ -86,6 +87,19 @@ Or via terminal:
 ```bash
 curl -X POST http://localhost:5050/api/chat   -H "Content-Type: application/json"   -d '{"messages":[{"role":"user","content":"Hello!"}]}'
 ```
+
+---
+
+## 🧪 Sample Prompt Scripts
+
+Example scripts live in `src/prompts` and demonstrate different tasks:
+
+```bash
+node src/prompts/translate.js   # Translate English to Spanish
+node src/prompts/summarize.js   # Summarize a paragraph
+```
+
+Ensure your `OPENAI_API_KEY` is available in the environment when running these.
 
 ---
 

--- a/src/App.js
+++ b/src/App.js
@@ -9,7 +9,7 @@ function App() {
             content: 'You are a helpful general knowledge expert.'
         },
         {
-            role: 'user',usl
+            role: 'user',
             content: 'Who invented the television?'
         }
     ];

--- a/src/prompts/summarize.js
+++ b/src/prompts/summarize.js
@@ -1,0 +1,24 @@
+import OpenAI from 'openai'
+
+const openai = new OpenAI({
+    dangerouslyAllowBrowser: true
+})
+
+const messages = [
+    {
+        role: 'system',
+        content: 'Summarize the user provided text into one short paragraph.'
+    },
+    {
+        role: 'user',
+        content: 'Artificial intelligence enables computers to perform tasks that typically require human intelligence, such as visu
+al perception, speech recognition, decision-making, and language translation.'
+    }
+]
+
+const response = await openai.chat.completions.create({
+    model: 'gpt-4',
+    messages
+})
+
+console.log(response.choices[0].message.content)

--- a/src/prompts/translate.js
+++ b/src/prompts/translate.js
@@ -1,0 +1,23 @@
+import OpenAI from 'openai'
+
+const openai = new OpenAI({
+    dangerouslyAllowBrowser: true
+})
+
+const messages = [
+    {
+        role: 'system',
+        content: 'You translate English text into Spanish.'
+    },
+    {
+        role: 'user',
+        content: 'The weather is nice today.'
+    }
+]
+
+const response = await openai.chat.completions.create({
+    model: 'gpt-4',
+    messages
+})
+
+console.log(response.choices[0].message.content)


### PR DESCRIPTION
## Summary
- add new translation and summarization sample scripts
- fix mis-typed user message in App.js
- document prompt examples in README

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a61e318d888324ba71974599b9e648